### PR TITLE
catch ImportError instead of reading __version__ number

### DIFF
--- a/pytest_spark/__init__.py
+++ b/pytest_spark/__init__.py
@@ -57,16 +57,14 @@ def spark_session():
     Available from Spark 2.0 onwards.
     """
 
-    from pyspark import __version__ as spark_version
-
-    if spark_version.startswith('0') or spark_version.startswith('1'):
+    try:
+        from pyspark.sql import SparkSession
+    except ImportError:
         raise Exception(
             'The "spark_session" fixture is only available on spark 2.0 '
             'and above. Please use the spark_context fixture and instanciate '
             'a SQLContext or HiveContext from it in your tests.'
         )
-
-    from pyspark.sql import SparkSession
 
     spark_session = SparkSession.builder.enableHiveSupport().getOrCreate()
     sc = spark_session.sparkContext


### PR DESCRIPTION
Hi again @malexer ...  Thanks for releasing a new version of `pytest-spark` so quickly!

However I found a problem in the version check code I added in the `spark_session` fixture. [`pyspark.__version__` is only defined from v2.1 onwards..](https://github.com/apache/spark/commits/master/python/pyspark/version.py). 😞 

This causes an ugly exception instead of showing an explanation message, and most importantly even prevents the fixture from working on spark 2.0 where it should be available.

the spark version can be read from `sparkContext.version`  in older versions but that requires an instances of `sparkContext` to be created which is not the case here. 

Instead I went for a simpler check to fix the issue: catch the `ImportError` in old spark versions and display a more helpful message.

Sorry about that!