### PR TITLE
read SPARK_HOME from environment as well as from pytest.ini

### DIFF
--- a/pytest_spark/__init__.py
+++ b/pytest_spark/__init__.py
@@ -24,7 +24,7 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    spark_home = config.getini('spark_home')
+    spark_home = os.environ.get('SPARK_HOME', config.getini('spark_home'))
 
     if spark_home:
         update_spark_home(spark_home)


### PR DESCRIPTION
It's useful to be able to set this from the environment (rather than hard coding it).
For example on different platforms (Linux, MacOS etc)