### PR TITLE
Improve Docker setup and update dependencies (related to #10)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,5 +8,3 @@ services:
             dockerfile: test_env/tox.Dockerfile
         image: pytest_spark/tests
         container_name: pytest-spark-tests
-        volumes:
-            - ./:/tests/

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,4 @@ spark_home = /opt/spark
 spark_options =
     spark.app.name: pytest-spark-tests
     spark.executor.instances: 1
-    spark.jars.packages: com.databricks:spark-xml_2.12:0.5.0
+    spark.jars.packages: com.databricks:spark-xml_2.11:0.5.0

--- a/test_env/download_spark.sh
+++ b/test_env/download_spark.sh
@@ -1,12 +1,14 @@
 #!/bin/sh
 
+set -x
+set -e
+
 SPARK_URL=$1
 TARGET_DIR=$2
 
-set -e
 
 mkdir -p /opt
-wget -q -O /opt/spark.tgz "$SPARK_URL"
+wget -nv -O /opt/spark.tgz "$SPARK_URL"
 tar xzf /opt/spark.tgz -C /opt/
 rm /opt/spark.tgz
 

--- a/test_env/tox.Dockerfile
+++ b/test_env/tox.Dockerfile
@@ -12,7 +12,7 @@ ENV SPARK16_URL https://archive.apache.org/dist/spark/spark-1.6.3/spark-1.6.3-bi
 RUN /download_spark.sh $SPARK16_URL /opt/spark16
 
 # install Spark 2.4
-ENV SPARK24_URL spark/spark-2.4.2/spark-2.4.2-bin-hadoop2.7.tgz
+ENV SPARK24_URL spark/spark-2.4.3/spark-2.4.3-bin-hadoop2.7.tgz
 RUN export APACHE_MIRROR=$(curl -s 'https://www.apache.org/dyn/closer.cgi?as_json=1' | python -c "import sys, json; print json.load(sys.stdin)['preferred']") \
     && export SPARK24_FULL_URL="${APACHE_MIRROR}${SPARK24_URL}" \
     && /download_spark.sh $SPARK24_FULL_URL /opt/spark24


### PR DESCRIPTION
Hi,

This PR does two things:

* Improve Docker compose's behaviour when running tests
* Update the Spark and spark-xml version dependencies

The second is fairly straightforward, but to explain the changes in the first:

* The volume definition is removed. Because the volume is persistent, it will overrule the `COPY` command in the Dockerfile which copies to the same location. Under the old version this meant you had to remove the volume before rebuilding if the local code had been changed. There is no reason to maintain the volume contents between runs of the container, so the volume is not necessary.
  * Additionally, the volume was originally mounted into the repository directory which meant that any test output, such as `__pycache__` directories, was placed in the user's directory as the root user. This avoids that inconvenience.
* The `download_spark.sh` script now sets `-x`, so that its commands are output before they are executed. This gives a similar output to what Docker does when running the Dockerfile.
* `wget` is called with the "not-verbose" flag instead of the "quiet" flag. Quiet suppresses all output including errors, which in my case meant I couldn't see that I was getting a 404 for the old URL.