### PR TITLE
Fix/hive parameter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,6 +99,33 @@ Example::
         test_df = spark_session.createDataFrame([[1,3],[2,4]], "a: int, b: int")
         # ...
 
+Overriding default parameters of the ``spark_session`` fixture
+---------------------------------------------------------
+By default ``spark_session`` will be loaded with the following configurations : 
+
+Example::
+
+    {
+        'spark.app.name': 'pytest-spark',
+        'spark.default.parallelism': 1,
+        'spark.dynamicAllocation.enabled': 'false',
+        'spark.executor.cores': 1,
+        'spark.executor.instances': 1,
+        'spark.io.compression.codec': 'lz4',
+        'spark.rdd.compress': 'false',
+        'spark.sql.shuffle.partitions': 1,
+        'spark.shuffle.compress': 'false',
+        'spark.sql.catalogImplementation': 'hive',
+    }
+
+You can override some of these parameters in your ``pytest.ini``. 
+For example, removing Hive Support for the spark session : 
+
+Example::
+    [pytest]
+    spark_home = /opt/spark
+    spark_options =
+        spark.sql.catalogImplementation: in-memory
 
 Development
 ===========

--- a/README.rst
+++ b/README.rst
@@ -100,7 +100,7 @@ Example::
         # ...
 
 Overriding default parameters of the ``spark_session`` fixture
----------------------------------------------------------
+--------------------------------------------------------------
 By default ``spark_session`` will be loaded with the following configurations : 
 
 Example::
@@ -122,6 +122,7 @@ You can override some of these parameters in your ``pytest.ini``.
 For example, removing Hive Support for the spark session : 
 
 Example::
+
     [pytest]
     spark_home = /opt/spark
     spark_options =

--- a/pytest_spark/config.py
+++ b/pytest_spark/config.py
@@ -10,6 +10,7 @@ class SparkConfigBuilder(object):
         'spark.rdd.compress': 'false',
         'spark.sql.shuffle.partitions': 1,
         'spark.shuffle.compress': 'false',
+        'spark.sql.catalogImplementation': 'hive',
     }
 
     options = None

--- a/pytest_spark/fixtures.py
+++ b/pytest_spark/fixtures.py
@@ -26,7 +26,6 @@ def _spark_session():
     else:
         session = SparkSession.builder \
             .config(conf=SparkConfigBuilder().get()) \
-            .enableHiveSupport() \
             .getOrCreate()
 
         yield session


### PR DESCRIPTION
Hey @malexer !
As suggested in #17 .
I did reproduce the bug I had and was able to solve it with this new version and the `spark.sql.catalogImplementation: in-memory` in the `pytest.ini`