### PR TITLE
feat: make deprecated parameter `startdir` optional

### DIFF
--- a/pytest_spark/__init__.py
+++ b/pytest_spark/__init__.py
@@ -34,7 +34,7 @@ def pytest_configure(config):
         SparkConfigBuilder().initialize(options_from_ini=spark_options)
 
 
-def pytest_report_header(config, start_path):
+def pytest_report_header(config, startdir=None):
     header_lines = []
     spark_ver = SparkHome(config).version
     if spark_ver:

--- a/pytest_spark/__init__.py
+++ b/pytest_spark/__init__.py
@@ -34,7 +34,7 @@ def pytest_configure(config):
         SparkConfigBuilder().initialize(options_from_ini=spark_options)
 
 
-def pytest_report_header(config, startdir=None):
+def pytest_report_header(config):
     header_lines = []
     spark_ver = SparkHome(config).version
     if spark_ver:

--- a/pytest_spark/__init__.py
+++ b/pytest_spark/__init__.py
@@ -34,7 +34,7 @@ def pytest_configure(config):
         SparkConfigBuilder().initialize(options_from_ini=spark_options)
 
 
-def pytest_report_header(config, startdir):
+def pytest_report_header(config, start_path):
     header_lines = []
     spark_ver = SparkHome(config).version
     if spark_ver:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(cwd, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='pytest-spark',
-    version='0.6.1',
+    version='0.6.0',
 
     description='pytest plugin to run the tests with support of pyspark.',
     long_description=long_description,
@@ -41,7 +41,7 @@ setup(
 
     keywords=('pytest spark pyspark unittest test'),
 
-    install_requires=['pytest>=7', 'findspark'],
+    install_requires=['pytest', 'findspark'],
     packages=['pytest_spark'],
     entry_points={
         'pytest11': [

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open(path.join(cwd, 'README.rst'), encoding='utf-8') as f:
 
 setup(
     name='pytest-spark',
-    version='0.6.0',
+    version='0.6.1',
 
     description='pytest plugin to run the tests with support of pyspark.',
     long_description=long_description,
@@ -41,7 +41,7 @@ setup(
 
     keywords=('pytest spark pyspark unittest test'),
 
-    install_requires=['pytest', 'findspark'],
+    install_requires=['pytest>=7', 'findspark'],
     packages=['pytest_spark'],
     entry_points={
         'pytest11': [


### PR DESCRIPTION
solution to #24

pytest 8.1.0 dropped deprecated startdir

start_path was introduced in [pytest 7.0.0
](https://github.com/pytest-dev/pytest/blob/7.0.0/src/_pytest/hookspec.py#L677)