### PR TITLE
fix pytest_report_header args for pytest 8.1.0

### DIFF
--- a/pytest_spark/__init__.py
+++ b/pytest_spark/__init__.py
@@ -34,7 +34,7 @@ def pytest_configure(config):
         SparkConfigBuilder().initialize(options_from_ini=spark_options)
 
 
-def pytest_report_header(config, startdir):
+def pytest_report_header(config, *args):
     header_lines = []
     spark_ver = SparkHome(config).version
     if spark_ver:


### PR DESCRIPTION
pytest-spark breaks as of pytest 8.1.0
As described in https://docs.pytest.org/en/7.1.x/reference/reference.html#pytest.hookspec.pytest_report_header 

> Changed in version 7.0.0: The start_path parameter was added as a [pathlib.Path](https://docs.python.org/3/library/pathlib.html#pathlib.Path) equivalent of the startdir parameter. The startdir parameter has been deprecated.

Since the parameter is unused, we can use dynamic positional arguments and fix pytest-spark